### PR TITLE
Technical/aa 252 separate deactivation reasons

### DIFF
--- a/HappyTravel.Nakijin.Api/Models/Mappers/SlimAccommodationData.cs
+++ b/HappyTravel.Nakijin.Api/Models/Mappers/SlimAccommodationData.cs
@@ -15,5 +15,7 @@ namespace HappyTravel.Nakijin.Api.Models.Mappers
         public Dictionary<Suppliers,string> SupplierAccommodationCodes { get; set; } = new Dictionary<Suppliers, string>();
 
         public bool IsActive { get; set; } = true;
+        
+        public DeactivationReasons DeactivationReason { get; set; }
     }
 }

--- a/HappyTravel.Nakijin.Api/Services/AccommodationManagementService.cs
+++ b/HappyTravel.Nakijin.Api/Services/AccommodationManagementService.cs
@@ -39,7 +39,7 @@ namespace HappyTravel.Nakijin.Api.Services
                 return Result.Failure(error);
 
             await AddOrUpdateMappings(uncertainMatch.SourceHtId, uncertainMatch.HtIdToMatch);
-
+            
             uncertainMatch.IsActive = false;
             uncertainMatch.Modified = DateTime.UtcNow;
 
@@ -149,6 +149,7 @@ namespace HappyTravel.Nakijin.Api.Services
             sourceAccommodation.Modified = utcDate;
 
             accommodationToMatch.IsActive = false;
+            accommodationToMatch.DeactivationReason = DeactivationReasons.MatchingWithOther;
             accommodationToMatch.Modified = utcDate;
 
             _context.Update(sourceAccommodation);

--- a/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
+++ b/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
@@ -40,10 +40,9 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
     */
     public class AccommodationMapper : IAccommodationMapper
     {
-        public AccommodationMapper(NakijinContext context,
-            ILoggerFactory loggerFactory, IOptions<StaticDataLoadingOptions> options,
-            MultilingualDataHelper multilingualDataHelper, AccommodationMappingsCache mappingsCache,
-            TracerProvider tracerProvider, AccommodationChangePublisher accommodationChangePublisher, AccommodationMapperHelper mapperHelper,
+        public AccommodationMapper(NakijinContext context, ILoggerFactory loggerFactory, IOptions<StaticDataLoadingOptions> options,
+            MultilingualDataHelper multilingualDataHelper, AccommodationMappingsCache mappingsCache, TracerProvider tracerProvider,
+            AccommodationChangePublisher accommodationChangePublisher, AccommodationMapperHelper mapperHelper,
             IAccommodationMapperDataRetrieveService accommodationMapperDataRetrieveService)
         {
             _context = context;
@@ -135,7 +134,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
 
                 var notActiveCountryAccommodationsOfSupplier = countryAccommodationsOfSupplier
                     .Where(ac => !ac.AccommodationKeyData.IsActive).ToList();
-                
+
                 // Process invalid not active accommodations, because they can be activated if data became valid on supplier side.
                 var invalidNotActiveCountryAccommodationsOfSupplier = notActiveCountryAccommodationsOfSupplier
                     .Where(ac => ac.AccommodationKeyData.DeactivationReason != DeactivationReasons.MatchingWithOther)
@@ -314,13 +313,12 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
             }
 
 
-            void AddOrChangeActivity(Contracts.MultilingualAccommodation accommodation, bool isActive,
+            void AddOrChangeActivity(Contracts.MultilingualAccommodation accommodation, bool isActive, 
                 DeactivationReasons deactivationReason = DeactivationReasons.None)
             {
                 if (isActive && activeCountryAccommodationsOfSupplier.ContainsKey(accommodation.SupplierCode))
                     return;
 
-                
                 if (isActive && invalidNotActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
                     out var existingNotActive))
                 {

--- a/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
+++ b/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
@@ -135,7 +135,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
 
                 var notActiveCountryAccommodationsOfSupplier = countryAccommodationsOfSupplier
                     .Where(ac => !ac.AccommodationKeyData.IsActive).ToList();
-
+                
+                // Process invalid not active accommodations, because they can be activated if data became valid on supplier side.
                 var invalidNotActiveCountryAccommodationsOfSupplier = notActiveCountryAccommodationsOfSupplier
                     .Where(ac => ac.AccommodationKeyData.DeactivationReason != DeactivationReasons.MatchingWithOther)
                     .ToDictionary(ac => ac.SupplierCode, ac => ac.AccommodationKeyData);
@@ -319,6 +320,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 if (isActive && activeCountryAccommodationsOfSupplier.ContainsKey(accommodation.SupplierCode))
                     return;
 
+                
                 if (isActive && invalidNotActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
                     out var existingNotActive))
                 {

--- a/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
+++ b/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapper.cs
@@ -43,7 +43,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
         public AccommodationMapper(NakijinContext context,
             ILoggerFactory loggerFactory, IOptions<StaticDataLoadingOptions> options,
             MultilingualDataHelper multilingualDataHelper, AccommodationMappingsCache mappingsCache,
-            TracerProvider tracerProvider, AccommodationChangePublisher accommodationChangePublisher, AccommodationMapperHelper mapperHelper, IAccommodationMapperDataRetrieveService accommodationMapperDataRetrieveService)
+            TracerProvider tracerProvider, AccommodationChangePublisher accommodationChangePublisher, AccommodationMapperHelper mapperHelper,
+            IAccommodationMapperDataRetrieveService accommodationMapperDataRetrieveService)
         {
             _context = context;
             _logger = loggerFactory.CreateLogger<AccommodationMapper>();
@@ -133,12 +134,16 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 var countryAccommodationsOfSupplier = await _accommodationMapperDataRetrieveService.GeCountryAccommodationBySupplier(country.Code, supplier);
 
                 var notActiveCountryAccommodationsOfSupplier = countryAccommodationsOfSupplier
-                    .Where(ac => !ac.AccommodationKeyData.IsActive)
+                    .Where(ac => !ac.AccommodationKeyData.IsActive).ToList();
+
+                var invalidNotActiveCountryAccommodationsOfSupplier = notActiveCountryAccommodationsOfSupplier
+                    .Where(ac => ac.AccommodationKeyData.DeactivationReason != DeactivationReasons.MatchingWithOther)
                     .ToDictionary(ac => ac.SupplierCode, ac => ac.AccommodationKeyData);
 
                 var activeCountryAccommodationsOfSupplier = countryAccommodationsOfSupplier
                     .Where(ac => ac.AccommodationKeyData.IsActive)
                     .ToDictionary(ac => ac.SupplierCode, ac => ac.AccommodationKeyData);
+
                 countryAccommodationsMappingSpan.AddEvent("Got supplier's specified country accommodations");
 
                 var activeCountryUncertainMatchesOfSupplier =
@@ -161,7 +166,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
 
                     skip += accommodationDetails.Count;
                     await Map(country, accommodationDetails, supplier, countryAccommodationsTree,
-                        activeCountryAccommodationsOfSupplier, notActiveCountryAccommodationsOfSupplier,
+                        activeCountryAccommodationsOfSupplier, invalidNotActiveCountryAccommodationsOfSupplier, notActiveCountryAccommodationsOfSupplier,
                         activeCountryUncertainMatchesOfSupplier, countryLocalities,
                         countryLocalityZones, htAccommodationMappings, countryAccommodationsMappingSpan,
                         cancellationToken);
@@ -177,7 +182,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
             List<Contracts.MultilingualAccommodation> accommodationsToMap,
             Suppliers supplier, STRtree<SlimAccommodationData> countryAccommodationsTree,
             Dictionary<string, SlimAccommodationData> activeCountryAccommodationsOfSupplier,
-            Dictionary<string, SlimAccommodationData> notActiveCountryAccommodationsOfSupplier,
+            Dictionary<string, SlimAccommodationData> invalidNotActiveCountryAccommodationsOfSupplier,
+            List<(string SupplierCode, SlimAccommodationData AccommodationKeyData)> notActiveCountryAccommodationsOfSupplier,
             List<Tuple<int, int>> activeCountryUncertainMatchesOfSupplier, Dictionary<string, int> countryLocalities,
             Dictionary<(int LocalityId, string LocalityZoneName), int> countryLocalityZones,
             Dictionary<int, (int Id, HashSet<int> MappedHtIds)> htAccommodationMappings,
@@ -198,7 +204,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 {
                     _logger.LogNotValidCoordinatesInAccommodation(
                         $"{supplier.ToString()} have the accommodation with not valid coordinates, which code is {accommodation.SupplierCode}");
-                    AddOrChangeActivity(normalized, false);
+                    AddOrChangeActivity(normalized, false, DeactivationReasons.InvalidCoordinates);
                     continue;
                 }
 
@@ -206,7 +212,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 {
                     _logger.LogNotValidDefaultNameOfAccommodation(
                         $"{supplier.ToString()} have the accommodation with not valid default name, which code is {accommodation.SupplierCode}");
-                    AddOrChangeActivity(normalized, false);
+                    AddOrChangeActivity(normalized, false, DeactivationReasons.InvalidName);
                     continue;
                 }
 
@@ -243,7 +249,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 .ToList();
 
             _context.AddRange(accommodationsToAdd);
-            _context.AddRange(uncertainAccommodationsToAdd); 
+            _context.AddRange(uncertainAccommodationsToAdd);
             await _context.SaveChangesAsync(cancellationToken);
 
             var accommodationsToPublish = accommodationsToAdd
@@ -280,7 +286,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                         return;
                     }
                 }
-                else if (notActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
+                else if (invalidNotActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
                     out var existingNotActive))
                 {
                     matchedHtId = existingNotActive.HtId;
@@ -307,25 +313,29 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
             }
 
 
-            void AddOrChangeActivity(Contracts.MultilingualAccommodation accommodation, bool isActive)
+            void AddOrChangeActivity(Contracts.MultilingualAccommodation accommodation, bool isActive,
+                DeactivationReasons deactivationReason = DeactivationReasons.None)
             {
                 if (isActive && activeCountryAccommodationsOfSupplier.ContainsKey(accommodation.SupplierCode))
                     return;
 
-                if (isActive && notActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
+                if (isActive && invalidNotActiveCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
                     out var existingNotActive))
                 {
                     var accommodationToUpdate = new RichAccommodationDetails
                     {
                         Id = existingNotActive.HtId,
                         IsActive = true,
-                        Modified = utcDate
+                        Modified = utcDate,
+                        DeactivationReason = deactivationReason
                     };
 
                     _context.Attach(accommodationToUpdate);
-                    _context.Entry(accommodationToUpdate).Property(ac => ac.IsActive).IsModified = true;
-                    _context.Entry(accommodationToUpdate).Property(ac => ac.Modified).IsModified = true;
 
+                    var entry = _context.Entry(accommodationToUpdate);
+                    entry.Property(ac => ac.IsActive).IsModified = true;
+                    entry.Property(ac => ac.Modified).IsModified = true;
+                    entry.Property(ac => ac.DeactivationReason).IsModified = true;
                     var keyData = _multilingualDataHelper.GetAccommodationKeyData(accommodation);
 
                     addedAccommodations.Add(new AccommodationData(existingNotActive.HtId, keyData.DefaultName,
@@ -334,7 +344,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                     return;
                 }
 
-                if (!isActive && notActiveCountryAccommodationsOfSupplier.ContainsKey(accommodation.SupplierCode))
+                if (!isActive && notActiveCountryAccommodationsOfSupplier.Any(ac => ac.SupplierCode == accommodation.SupplierCode))
                     return;
 
                 if (!isActive && activeCountryAccommodationsOfSupplier.TryGetValue(accommodation.SupplierCode,
@@ -344,18 +354,22 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                     {
                         Id = existingActive.HtId,
                         IsActive = false,
+                        DeactivationReason = deactivationReason,
                         Modified = utcDate
                     };
 
                     _context.Attach(accommodationToUpdate);
-                    _context.Entry(accommodationToUpdate).Property(ac => ac.IsActive).IsModified = true;
-                    _context.Entry(accommodationToUpdate).Property(ac => ac.Modified).IsModified = true;
+
+                    var entry = _context.Entry(accommodationToUpdate);
+                    entry.Property(ac => ac.IsActive).IsModified = true;
+                    entry.Property(ac => ac.DeactivationReason).IsModified = true;
+                    entry.Property(ac => ac.Modified).IsModified = true;
 
                     removedAccommodations.Add(existingActive.HtId);
                     return;
                 }
 
-                var dbAccommodation = GetDbAccommodation(accommodation, isActive);
+                var dbAccommodation = GetDbAccommodation(accommodation, isActive, deactivationReason);
                 accommodationsToAdd.Add(dbAccommodation);
             }
 
@@ -374,7 +388,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 {
                     _logger.LogSameAccommodationInOneSupplierError(
                         $"{supplier.ToString()} have the same accommodations with codes {matchedAccommodation.SupplierAccommodationCodes[supplier]} and {accommodation.SupplierCode}");
-                    AddOrChangeActivity(accommodation, false);
+                    AddOrChangeActivity(accommodation, false, DeactivationReasons.DuplicateInOneSupplier);
                     return;
                 }
 
@@ -386,7 +400,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
 
                     _logger.LogSameAccommodationInOneSupplierError(
                         $"{supplier.ToString()} have the same accommodations with codes {entry.Entity.SupplierAccommodationCodes[supplier]} and {accommodation.SupplierCode}");
-                    AddOrChangeActivity(accommodation, false);
+                    AddOrChangeActivity(accommodation, false, DeactivationReasons.DuplicateInOneSupplier);
                     return;
                 }
 
@@ -401,7 +415,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                     {
                         Id = existingAccommodation.HtId,
                         Modified = utcDate,
-                        IsActive = false
+                        IsActive = false,
+                        DeactivationReason = DeactivationReasons.MatchingWithOther
                     };
 
                     removedAccommodations.Add(existingAccommodation.HtId);
@@ -465,8 +480,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
             }
 
 
-            RichAccommodationDetails GetDbAccommodation(Contracts.MultilingualAccommodation accommodation,
-                bool isActive)
+            RichAccommodationDetails GetDbAccommodation(Contracts.MultilingualAccommodation accommodation, bool isActive,
+                DeactivationReasons deactivationReasons = DeactivationReasons.None)
             {
                 var dbAccommodation = new RichAccommodationDetails();
                 dbAccommodation.CountryCode = country.Code;
@@ -482,6 +497,7 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                 dbAccommodation.LocalityId = locationIds.LocalityId;
                 dbAccommodation.LocalityZoneId = locationIds.LocalityZoneId;
                 dbAccommodation.IsActive = isActive;
+                dbAccommodation.DeactivationReason = deactivationReasons;
 
                 return dbAccommodation;
             }

--- a/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapperDataRetrieveService.cs
+++ b/HappyTravel.Nakijin.Api/Services/Workers/AccommodationMapping/AccommodationMapperDataRetrieveService.cs
@@ -63,7 +63,8 @@ namespace HappyTravel.Nakijin.Api.Services.Workers.AccommodationMapping
                     {
                         HtId = ac.Id,
                         SupplierAccommodationCodes = ac.SupplierAccommodationCodes,
-                        IsActive = ac.IsActive
+                        IsActive = ac.IsActive,
+                        DeactivationReason = ac.DeactivationReason
                     })
                     .ToListAsync();
 

--- a/HappyTravel.Nakijin.Data/Migrations/20210526130608_DeactivationReasonOfAccommodation.Designer.cs
+++ b/HappyTravel.Nakijin.Data/Migrations/20210526130608_DeactivationReasonOfAccommodation.Designer.cs
@@ -6,15 +6,17 @@ using HappyTravel.MultiLanguage;
 using HappyTravel.Nakijin.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace HappyTravel.Nakijin.Data.Migrations
 {
     [DbContext(typeof(NakijinContext))]
-    partial class NakijinContextModelSnapshot : ModelSnapshot
+    [Migration("20210526130608_DeactivationReasonOfAccommodation")]
+    partial class DeactivationReasonOfAccommodation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.Nakijin.Data/Migrations/20210526130608_DeactivationReasonOfAccommodation.cs
+++ b/HappyTravel.Nakijin.Data/Migrations/20210526130608_DeactivationReasonOfAccommodation.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.Nakijin.Data.Migrations
+{
+    public partial class DeactivationReasonOfAccommodation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DeactivationReason",
+                table: "Accommodations",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeactivationReason",
+                table: "Accommodations");
+        }
+    }
+}

--- a/HappyTravel.Nakijin.Data/Models/Accommodations/RichAccommodationDetails.cs
+++ b/HappyTravel.Nakijin.Data/Models/Accommodations/RichAccommodationDetails.cs
@@ -24,7 +24,8 @@ namespace HappyTravel.Nakijin.Data.Models.Accommodations
             new Dictionary<Suppliers, string>();
 
         public bool IsCalculated { get; set; }
-        public bool IsActive { get; set; }
+        public bool IsActive { get; set; }    
+        public DeactivationReasons DeactivationReason { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
 

--- a/HappyTravel.Nakijin.Data/Models/DeactivationReasons.cs
+++ b/HappyTravel.Nakijin.Data/Models/DeactivationReasons.cs
@@ -2,10 +2,10 @@ namespace HappyTravel.Nakijin.Data.Models
 {
     public enum DeactivationReasons
     {
-        None,
-        InvalidCoordinates,
-        InvalidName,
-        DuplicateInOneSupplier,
-        MatchingWithOther
+        None = 0,
+        InvalidCoordinates = 1,
+        InvalidName = 2,
+        DuplicateInOneSupplier = 3,
+        MatchingWithOther = 4
     }
 }

--- a/HappyTravel.Nakijin.Data/Models/DeactivationReasons.cs
+++ b/HappyTravel.Nakijin.Data/Models/DeactivationReasons.cs
@@ -1,0 +1,11 @@
+namespace HappyTravel.Nakijin.Data.Models
+{
+    public enum DeactivationReasons
+    {
+        None,
+        InvalidCoordinates,
+        InvalidName,
+        DuplicateInOneSupplier,
+        MatchingWithOther
+    }
+}

--- a/HappyTravel.Nakijin.Data/NakijinContext.cs
+++ b/HappyTravel.Nakijin.Data/NakijinContext.cs
@@ -88,6 +88,7 @@ namespace HappyTravel.Nakijin.Data
                     .IsRequired();
                 a.Property(p => p.IsCalculated).IsRequired().HasDefaultValue(true);
                 a.Property(p => p.IsActive).IsRequired();
+                a.Property(p => p.DeactivationReason).IsRequired();
                 a.Property(p => p.Created)
                     .IsRequired()
                     .HasDefaultValueSql("now() at time zone 'utc'");


### PR DESCRIPTION
Separated logic of invalid not active accommodations(they can be activated when data on supplier side became valid) and not active matched accommodations( can not activated).